### PR TITLE
Typo cleanup and clarifications

### DIFF
--- a/Documentation/Commands.rst
+++ b/Documentation/Commands.rst
@@ -3,11 +3,13 @@
 Commands
 ========
 
-Commands are the basic value objects, or models, that represent write
-operations that you can perform in your domain.
+Commands are the basic value objects, or models, that represent the 
+*write operations* that you can perform in your domain. As described 
+in more detail below a command is the "thing" to be done.  A command 
+handler **does** the "thing".
 
-As an example, one might implement create this command for updating user
-passwords.
+As an example, one might implement this command for updating user
+passwords.  
 
 .. literalinclude:: ../Source/EventFlow.Documentation/Topics/Commands/UserUpdatePasswordCommand.cs
   :linenos:
@@ -35,10 +37,10 @@ one) command handler which is responsible for invoking the aggregate.
 Execution results
 -----------------
 
-If the aggregate detects a domain error an want to abort execution and
-return an error back, execution results are used. EventFlow ships with
-a basic implementation that allows returning a success and failed
-along with a error message as show here.
+If the aggregate detects a domain error and wants to abort execution 
+and return an error back, then execution results are used. EventFlow
+ships with a basic implementation that allows returning *success* or 
+*failed* and optionally an error message as shown here.
 
 .. code-block:: c#
 
@@ -47,9 +49,9 @@ along with a error message as show here.
     ExecutionResult.Failed("With some error");
 
 However, you can create your own custom execution results to allow
-aggregates to e.g. provide detailed validation results, merely
+aggregates to e.g. provide detailed validation results. Merely
 implement the ``IExecutionResult`` interface and use the type as
-generic generic arguments on the command and command handler.
+generic arguments on the command and command handler.
 
 .. NOTE::
     While possible, do not use the execution results as a method of reading
@@ -76,14 +78,16 @@ following simplified scenario.
 
 Handling this is simple, merely ensure that the aggregate is idempotent
 is regards to password changes. But instead of implementing this
-yourself, EventFlow has support for it and its simple to utilize and is
+yourself, EventFlow has support for it that is simple to utilize and is
 done per command.
 
 To use the functionality, merely ensure that commands that represent the
-same operation has the same ``ISourceId`` which implements ``IIdentity``
+same operation have the same ``ISourceId`` which implements ``IIdentity``
 like the example blow.
 
 .. code-block:: c#
+  :linenos:
+  :dedent: 4
 
     public class UserUpdatePasswordCommand : Command<UserAggregate, UserId>
     {
@@ -102,7 +106,7 @@ like the example blow.
       }
     }
 
-Note the use of the other ``protected`` constructor of ``Command<,>``
+Note the use on line 11 of the  ``protected`` constructor of ``Command<,>``
 that takes a ``ISourceId`` in addition to the aggregate root identity.
 
 If a duplicate command is detected, a ``DuplicateOperationException`` is
@@ -121,7 +125,7 @@ somewhat cumbersome, which is why EventFlow provides another base
 command you can use, the ``DistinctCommand<,>``. By using the
 ``DistinctCommand<,>`` you merely have to implement the
 ``GetSourceIdComponents()`` and providing the ``IEnumerable<byte[]>``
-that makes the command unique. The bytes is used to create a
+that makes the command unique. The bytes are used to create a
 deterministic GUID to be used as an ``ISourceId``.
 
 .. code-block:: c#
@@ -155,4 +159,4 @@ the password.
 .. CAUTION::
 
     Don't use the ``GetHashCode()``, as the implementation
-    is different for e.g. ``string`` on 32 bit and 64 bit .NET.
+    can be different on 32 bit and 64 bit .NET (e.g. ``string``).

--- a/Documentation/DosAndDonts.rst
+++ b/Documentation/DosAndDonts.rst
@@ -58,6 +58,6 @@ how EventFlow supports you in this.
 Subscribers and out of order events
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Be very careful if aggregates emits multiple events for a single command,
+Be very careful if aggregates emit multiple events for a single command,
 subscribers will almost certainly
 :ref:`receive these out of order <out-of-order-event-subscribers>`.

--- a/Documentation/GettingStarted.rst
+++ b/Documentation/GettingStarted.rst
@@ -141,8 +141,8 @@ very simple.
 Aggregate
 ---------
 
-Now we'll take a look at the ``ExampleAggregate``. Its rather simple as the
-only thing it can, is apply the magic number once.
+Now we'll take a look at the ``ExampleAggregate``. It is rather simple as the
+only thing it can do, is apply the magic number once.
 
 .. literalinclude:: ../Source/EventFlow.Documentation/GettingStarted/ExampleAggregate.cs
   :linenos:
@@ -155,7 +155,7 @@ details right, but for now the most important thing to note, is that the state
 of the aggregate (updating the ``_magicNumber`` variable) happens in the
 ``Apply(ExampleEvent)`` method. This is the event sourcing part of EventFlow in
 effect. As state changes are only saved as events, mutating the aggregate state
-must happen in such a way that the state changes are replayed the next the
+must happen in such a way that the state changes are replayed the next time the
 aggregate is loaded. EventFlow has a :ref:`set of different approaches <aggregates_applying_events>`
 that you can select from, but in this example we use the `Apply` methods as
 they are the simplest.
@@ -187,7 +187,7 @@ command handler.
 Event
 -----
 
-Next up is the event which represents some that **has** happend in our domain.
+Next up is the event which represents some thing that **has** happened in our domain.
 In this example, its merely that some magic number has been set. Normally
 these events should have a really, really good name and represent something in the
 ubiquitous language for the domain.
@@ -205,12 +205,12 @@ event mentioned. The information is used by EventFlow to tie name and version to
 a specific .NET type.
 
 .. IMPORTANT::
-    Even though the using the ``EventVersion`` attribute is optional, its
+    Even though the using the ``EventVersion`` attribute is optional, it is
     **highly recommended**. EventFlow will infer the information if it isn't
-    provided and thus making it vulnerable to e.g. type renames.
+    provided and thus making it vulnerable to type renames among other things.
 
 .. IMPORTANT::
-    Once have aggregates in your production environment that have emitted
+    Once you have aggregates in your production environment that have emitted
     an event, you should never change the .NET implementation. You can deprecate
     it, but you should never change the type or the data stored in the event
     store.
@@ -228,7 +228,7 @@ application, they are published using the ``ICommandBus`` as shown here.
   :language: c#
   :lines: 55-59
 
-In EventFlow commands are simple value objects that merely how the arguments for
+In EventFlow commands are simple value objects that merely house the arguments for
 the command execution. All commands implement the ``ICommand<,>`` interface, but
 EventFlow provides an easy-to-use base class that you can use.
 


### PR DESCRIPTION
- Fixed a typo in Documentation/DosAndDonts
- Fixed several typos in Documentation/GettingStartedGettingStarted
- Fixed typos and added clarifications in Documentation/Commands