### PR TITLE
Fixing Typos; reformatting; clarification and wordsmithing

### DIFF
--- a/Documentation/Commands.rst
+++ b/Documentation/Commands.rst
@@ -70,7 +70,7 @@ following simplified scenario.
 2. The user fills in the "change password form"
 3. As user is impatient, or by accident, the user submits the for twice
 4. The first web request completes and the password is changed. However,
-   as the browser is waiting on the first web request, this result is
+   as the browser is waiting on the second web request, this result is
    ignored
 5. The second web request throws a domain error as the "old password"
    doesn't match as the current password has already been changed
@@ -83,7 +83,7 @@ done per command.
 
 To use the functionality, merely ensure that commands that represent the
 same operation have the same ``ISourceId`` which implements ``IIdentity``
-like the example blow.
+like the example below.
 
 .. code-block:: c#
   :linenos:
@@ -114,8 +114,8 @@ thrown. The application could then ignore the exception or report the
 problem to the end user.
 
 The default ``ISourceId`` history size of the aggregate root, is ten.
-But it can be configured using the ``SetSourceIdHistory(...)`` that must
-be called from within the aggregate root constructor.
+But it can be configured using the ``SetSourceIdHistory(...)`` method 
+in the aggregate root constructor.
 
 Easier ISourceId calculation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Documentation/EventStore.rst
+++ b/Documentation/EventStore.rst
@@ -79,7 +79,7 @@ Files
 
 .. IMPORTANT::
 
-    Files event shouldn't be used for production environments, only for tests.
+    The Files event store shouldn't be used for production environments, only for tests.
 
 
 The file based event store is useful if you have a set of events that represents

--- a/Documentation/GettingStarted.rst
+++ b/Documentation/GettingStarted.rst
@@ -34,7 +34,7 @@ The above line does configures several important defaults
     - :ref:`Snapshots <snapshots>`
 
 
-To start using EventFlow, a domain must be configure which consists of the
+To start using EventFlow, a domain must be configured which consists of the
 following parts
 
 - :ref:`Aggregate <aggregates>`

--- a/Documentation/Identity.rst
+++ b/Documentation/Identity.rst
@@ -4,10 +4,10 @@ Identity
 ========
 
 The ``Identity<>`` value object provides generic functionality to create
-and validate the IDs of e.g. aggregate roots. Its basically a wrapper
+and validate the IDs of aggregate roots. It is basically a wrapper
 around a ``Guid``.
 
-Lets say we want to create a new identity named ``TestId`` we could do
+Lets say we want to create a new identity named ``TestId``. We could do
 it like this.
 
 .. code-block:: c#
@@ -20,21 +20,21 @@ it like this.
       }
     }
 
--  The identity follow the form ``{class without "Id"}-{guid}`` e.g.
+-  The identity follows the form ``{classname without "Id"}-{guid}`` e.g.
    ``test-c93fdb8c-5c9a-4134-bbcd-87c0644ca34f`` for the above
    ``TestId`` example
 -  The internal ``Guid`` can be generated using one of the following
    methods/properties. Note that you can access the ``Guid`` factories
    directly by accessing the static methods on the ``GuidFactories``
    class
--  ``New``: Uses the standard ``Guid.NewGuid()``
--  ``NewDeterministic(...)``: Creates a name-based ``Guid`` using the
-   algorithm from `RFC 4122 <https://www.ietf.org/rfc/rfc4122.txt>`__
-   §4.3, which allows identities to be generated based on known data,
-   e.g. an user e-mail, i.e., it always returns the same identity for
-   the same arguments
--  ``NewComb()``: Creates a sequential ``Guid`` that can be used to e.g.
-   avoid database fragmentation
+   -  ``New``: Uses the standard ``Guid.NewGuid()``
+   -  ``NewDeterministic(...)``: Creates a name-based ``Guid`` using the
+      algorithm from `RFC 4122 <https://www.ietf.org/rfc/rfc4122.txt>`__
+      §4.3, which allows identities to be generated based on known data,
+      (e.g. an user e-mail). It always returns the same identity for
+      the same arguments
+   -  ``NewComb()``: Creates a sequential ``Guid`` that can be used to
+      avoid database fragmentation
 -  A ``string`` can be tested to see if its a valid identity using the
    static ``bool IsValid(string)`` method
 -  Any validation errors can be gathered using the static
@@ -63,7 +63,7 @@ Here's some examples on we can use our newly created ``TestId``
 
 .. code-block:: c#
 
-    // Creates a new identity every time, but an identity when used in e.g.
+    // Creates a new identity every time, but an identity when used in
     // database indexes, minimizes fragmentation
     var testId = TestId.NewComb()
 

--- a/Documentation/RabbitMQ.rst
+++ b/Documentation/RabbitMQ.rst
@@ -3,7 +3,7 @@
 RabbitMQ
 ========
 
-To setup EventFlow RabbitMQ_ integration, install the NuGet package
+To setup EventFlow's RabbitMQ_ integration, install the NuGet package
 ``EventFlow.RabbitMQ`` and add this to your EventFlow setup.
 
 .. code-block:: c#

--- a/Documentation/ReadStores.rst
+++ b/Documentation/ReadStores.rst
@@ -178,7 +178,7 @@ is used to store the read model version in.
 
 .. IMPORTANT::
 
-    EventFlow expect the read model to exist, and thus any
+    EventFlow expects the read model to exist, and thus any
     maintenance of the database schema for the read models must be handled
     before EventFlow is initialized. Or, at least before the read models are
     used in EventFlow.

--- a/Documentation/Sagas.rst
+++ b/Documentation/Sagas.rst
@@ -3,8 +3,8 @@
 Sagas
 =====
 
-To coordinates messages between bounded contexts and aggregates
-EventFlow provides a simple saga system.
+EventFlow provides a simple saga system to coordinate messages between 
+bounded contexts and aggregates.
 
 -  **Saga identity**
 -  **Saga**
@@ -84,14 +84,14 @@ the ubiquitous language for your domain.
     Even though the method for publishing commands is named
     ``Publish``, the commands are only published to the command bus
     **after** the aggregate has been successfully committed to the event
-    store (just like events). If an unexpected exception is throw by this
+    store (just like events). If an unexpected exception is thrown by this
     command publish, it should be handled by a custom implementation of
     ``ISagaErrorHandler``.
 
 
-The next few events and commands are omitted, but at last the
+The next few events and commands are omitted in this example, but at last the
 ``PaymentAggregate`` emits its ``PaymentAccepted`` event and the saga
-completes and emit the final ``OrderConfirmed`` event.
+completes and emits the final ``OrderConfirmed`` event.
 
 .. code-block:: c#
 

--- a/Documentation/Subscribers.rst
+++ b/Documentation/Subscribers.rst
@@ -3,16 +3,16 @@
 Subscribers
 ============
 
-Whenever your application needs to act when a specific event is emitted
-from your domain you create a class that implement one of the following
-two interfaces which is.
+Whenever your application needs to perform an action when a specific 
+event is emitted from your domain you create a class that implementations
+one of the following two interfaces:
 
 -  ``ISubscribeSynchronousTo<TAggregate,TIdentity,TEvent>``: Executed
-   synchronous
+   synchronously
 -  ``ISubscribeAsynchronousTo<TAggregate,TIdentity,TEvent>``: Executed
-   asynchronous
+   asynchronously
 
-Any implemented subscribers needs to be registered to this interface,
+Any subscribers that you implement need to be registered to this interface,
 either using ``AddSubscriber(...)``, ``AddSubscribers(...)`` or
 ``AddDefaults(...)`` during initialization. If you have configured a
 custom IoC container, you can register the implementations using it
@@ -35,7 +35,7 @@ Synchronous subscribers in EventFlow are executed one at a time for each
 emitted domain event in order. This e.g. guarantees that all subscribers
 have been executed when the ``ICommandBus.PublishAsync(...)`` returns.
 
-The ``ISubscribeSynchronousTo<,,>`` is shown here.
+The ``ISubscribeSynchronousTo<,,>`` interface is shown here.
 
 .. code-block:: c#
 
@@ -58,7 +58,7 @@ As synchronous subscribers are by their very nature executed
 synchronously, emitting multiple events from an aggregate and letting
 subscribers publish new commands based on this can however lead to some
 unexpected behavior as "innermost" subscribers will be executed before
-first.
+the next "outer" event is handled by the subscriber.
 
 1. Aggregate emits events ``Event 1`` and ``Event 2``
 2. Subscriber handles ``Event 1`` and publishes a command that results
@@ -68,8 +68,8 @@ first.
 
 In the above example the subscriber will handle the events in the
 following order ``Event 1``, ``Event 3`` and then ``Event 2``. While
-this *could* occur in a distributed system or executing subscribers on
-different threads, its a certainty when using synchronous subscribers.
+this *could* occur in a distributed system or when executing subscribers on
+different threads, it is a certainty when using synchronous subscribers.
 
 
 Exceptions swallowed by default
@@ -78,10 +78,10 @@ Exceptions swallowed by default
 By default any exceptions thrown by a subscriber are **swallowed**
 by EventFlow after it has been logged as an error. Depending on the
 application this might be the preferred behavior, but in some cases
-it isn't. If subscriber exception should be thrown, and thus allowing
+it isn't. If a subscriber exception should be thrown, and thus allowing
 them to be caught in e.g. command handlers, the behaivor can be disabled
-by setting the ``ThrowSubscriberExceptions`` to ``true`` like illustrated
-here.
+by setting the ``ThrowSubscriberExceptions`` to ``true`` as illustrated
+here:
 
 .. code-block:: c#
 
@@ -111,8 +111,9 @@ Asynchronous subscribers in EventFlow are executed using a scheduled job.
 
 .. IMPORTANT::
     As asynchronous subscribers are executed using a job, its important
-    to configure proper job scheduling by e.g. using the
-    ``EventFlow.Hangfire`` NuGet package.
+    to configure proper job scheduling. The ``EventFlow.Hangfire`` NuGet 
+    package integrates with the 'HangFire Job Scheduler <https://www.hangfire.io>, 
+    and provides a usable solution to this requirement.
 
 The ``ISubscribeAsynchronousTo<,,>`` is shown here and is, besides its
 name, identical to its synchronous counterpart.
@@ -181,9 +182,9 @@ Which will be the following for an event named ``CreateUser`` version
 Note the lowercasing and adding of ``-`` whenever there's a capital
 letter.
 
-All the above is the default behavior, if you don't like it replace e.g.
-the service ``IRabbitMqMessageFactory`` to customize what routing key or
-exchange to use. Have a look at how
+All the above is the default behavior, if you don't like it replace the 
+registered message factory service ``IRabbitMqMessageFactory`` to 
+customize what routing key or exchange to use. Have a look at how
 `EventFlow <https://github.com/rasmus/EventFlow>`__ has done its
 implementation to get started.
 


### PR DESCRIPTION
- Command.rst - typo correction; clarification of SetSourceIdHistory usage
- EventStore.rst - wordsmithing
- GettingStarted.rst - typo correction
- Identity.rst - eliminated some 'e.g.' abbreviations to make the text flow more cleanly; reformatting of GuidFactories methods list
- RabbitMQ.rst - typo correction
- ReadStore.rst - typo correction
- Sagas.rst - typo correction; wordsmithing
- Subscribers.rst - typo correction; wordsmithing