### PR TITLE
Add postgreSql basic docs

### DIFF
--- a/Documentation/EventStore.rst
+++ b/Documentation/EventStore.rst
@@ -72,6 +72,14 @@ application install or update, e.g., when the web site is installed.
     ``eventdatamodel_list_type``. EventFlow uses this type to pass entire
     batches of events to the database.
 
+.. _eventstore-postgresql:
+
+PostgreSql event store
+--------
+
+Basically all above on MS SQL server store applicable to PostgreSql. See :ref:`MSSQL setup <setup-postgresql>` 
+for setup documentation.
+
 .. _eventstore-mongodb:
 
 Mongo DB

--- a/Documentation/PostgreSql.rst
+++ b/Documentation/PostgreSql.rst
@@ -1,0 +1,27 @@
+.. _setup-postgresql:
+
+PostgreSql
+====================
+
+To setup EventFlow PostgreSql integration, install the NuGet
+package ``[EventFlow.PostgreSql](https://www.nuget.org/packages/EventFlow.PostgreSql)`` and add this to your EventFlow setup.
+
+.. code-block:: c#
+
+    IRootResolver rootResolver = EventFlowOptions.New
+      .ConfigurePostgreSql(PostgreSqlConfiguration.New
+        .SetConnectionString(@"User ID=me;Password=???;Host=localhost;Port=5432;Database=MyApp"))
+      .UsePostgreSqlEventStore()
+      .UsePostgreSqlSnapshotStore()
+      .UsePostgreSqlReadModel<UserReadModel>()
+      .UsePostgreSqlReadModel<UserNicknameReadModel,UserNicknameReadModelLocator>()
+      .
+      ...
+      .CreateResolver();
+
+This code block configures Eventflow to store events, snapshots and read models in PostgreSql. It's not mandatory, you 
+can mix and match, i.e. storing events in PostgreSql, read models in Elastic search and don't using snapshots at all.
+
+- Event store. One big table `EventFlow` for all events for all aggredates.
+- Read model store. Table `ReadModel-[ClassName]` per read model type. 
+- Snapshot store. One big table `EventFlowSnapshots` for all aggredates.

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -49,6 +49,7 @@ Contents:
    :caption: Integration
 
    MSSQL
+   PostgreSql
    RabbitMQ
 
 


### PR DESCRIPTION
During my attempts to understand how data stored in PostgreSql store, I decided to document bits of it. Everything is trivial, but m.b. could save somebody digging into the code.
I couldn't get docs to build locally, but I trust you have readthedocs setup to do branch builds, so it could be validated here.