### PR TITLE
Getting Started doc should mention another important dependency

### DIFF
--- a/Documentation/GettingStarted.rst
+++ b/Documentation/GettingStarted.rst
@@ -24,8 +24,9 @@ The above line does configures several important defaults
 - And lastly, default implementations of all the internal parts of EventFlow
 
 .. IMPORTANT::
-    If you're using ASP.NET Core, you should install the ***EventFlow.AspNetCore*** package and invoke
-    `AddAspNetCoreMetadataProviders` in Startup.
+    If you're using ASP.NET Core, you should install the 
+    ***EventFlow.AspNetCore*** and ***EventFlow.DependencyInjection*** packages
+    and invoke `AddAspNetCoreMetadataProviders` in Startup.
 
 .. code-block:: c#
 


### PR DESCRIPTION
Updated Getting Started doc to mention the `EventFlow.DependencyInjection` that needs to be referenced in order to use `AddEventFlow` extension.