### PR TITLE
Updated GettingStarted.rst

### DIFF
--- a/Documentation/GettingStarted.rst
+++ b/Documentation/GettingStarted.rst
@@ -24,8 +24,8 @@ The above line does configures several important defaults
 - And lastly, default implementations of all the internal parts of EventFlow
 
 .. IMPORTANT::
-    If you're using ASP.NET Core, you should install the ***EventFlow.AspNetCore*** package and invoke
-    `AddAspNetCoreMetadataProviders` in Startup.
+    If you're using ASP.NET Core, you should install ***EventFlow.AspNetCore*** and ***EventFlow.DependencyInjection*** packages and invoke
+    `AddAspNetCore` in Startup.
 
 .. code-block:: c#
 
@@ -34,7 +34,10 @@ The above line does configures several important defaults
         services.AddEventFlow(ef =>
         {
             ef.AddDefaults(typeof(Startup).Assembly);
-            ef.AddAspNetCoreMetadataProviders();
+            ef.AddAspNetCore(opt =>
+            {
+                opt.AddDefaultMetadataProviders();
+            });
         });
     }
 


### PR DESCRIPTION
Extra package `EventFlow.DependencyInjection` needs to be installed to use `services.AddEventFlow()`; 
`ef.AddAspNetCoreMetadataProviders()` is obsolete;
See https://stackoverflow.com/questions/66875437/eventflow-registration-in-net-core-3-1-api